### PR TITLE
Update README with correct import definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can use the connection following way:
 
 ```python
 from nameko.rpc import rpc
-import MongoDatabase from nameko_mongodb
+from nameko_mongodb import MongoDatabase
 
 
 class YourService(object):
@@ -56,7 +56,7 @@ Also this package can log all executions to `logging` collection. If you want to
 
 ```python
 from nameko.rpc import rpc
-import MongoDatabase from nameko_mongodb
+from nameko_mongodb import MongoDatabase
 
 
 class YourService(object):
@@ -86,7 +86,7 @@ How to use callbacks:
 
 ```python
 from nameko.rpc import rpc
-import MongoDatabase from nameko_mongodb
+from nameko_mongodb import MongoDatabase
 
 
 class YourService(object):


### PR DESCRIPTION
Hi :)

Unless I am missing something very obvious, I think that the code examples at `README` file define incorrectly the import of `MongoDatabase`.  So I just have updated those code examples.
